### PR TITLE
feat!: rename StageSetupInitPlan to StageSetup

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,8 +13,7 @@ concurrency:
 
 jobs:
   pre-commit:
-    runs-on: self-hosted-main
-    continue-on-error: true
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
     - uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08 # tag=v4

--- a/README.md
+++ b/README.md
@@ -10,14 +10,73 @@ If you need to configure a terraform provider for your tests, save that configur
 
 ## Functions
 
-* `StageSetupInitPlan`: Saves the `terraformOptions`, runs `terraform init` and `terraform plan`. You can specify an `errorFunc` here.
+### Stages
+
+When stages are used, you can set a `SKIP_$stage` environment variable to skip a certain stage, e.g. `SKIP_destroy`. This makes developing and debugging tests much easier.
+
+* `StageSetup`: Saves the `terraformOptions`, runs `terraform init` and `terraform plan`. You can specify an `errorFunc` here.
 * `StageApply`: Runs `terraform apply`. You can specify an `errorFunc` here.
 * `StageValidate`: If you want to check the state of the deployed infrastructure, you can do so in the validate stage. Pass a `validateFunc` into `StageValidate`.
-* `StageDestroy`: Destroys the resources, cleans up test data and a provider configuration if it exists.
+* `StageDestroy`: Runs `terraform destroy` and calls the `Cleanup` function.
+
+### Others
+
+* `Cleanup`: Removes the test data directory `.test-data` and test provider configuration `test-provider.tf`.
 
 ## Example
 
-Will follow.
+### Standard test
+
+```go
+func TestS3BucketDefault(t *testing.T) {
+	defer helpers.StageDestroy(t, TerraformDir)
+
+	// set everything up for the terraform apply later
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: TerraformDir,
+		Vars: map[string]interface{}{
+			"name":        uuid.New(),
+		},
+	})
+
+	helpers.StageSetup(t, TerraformDir, terraformOptions)
+	helpers.StageApply(t, TerraformDir)
+}
+```
+
+### Expected to fail
+
+For a test that is expected to fail on plan, use the `Cleanup` function.
+
+```go
+func TestS3BucketBackupOnVersioningOff(t *testing.T) {
+	defer helpers.Cleanup(t, TerraformDir)
+
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		TerraformDir: TerraformDir,
+		// NoColor is important for the string.Contains later
+		NoColor: true,
+		Vars: map[string]interface{}{
+			"name":        uuid.New(),
+			"backup":      "on",
+			"versioning":  "Disabled",
+		},
+	})
+
+	// The terraform plan is expected to fail as versioning can't be turned off with backups turned on.
+	helpers.StageSetup(t, TerraformDir, terraformOptions, func(err error, stdoutStderr string) {
+		// This error is expected, the precondition failed
+		if err != nil {
+			if !strings.Contains(stdoutStderr, "Error: Resource precondition failed") || !strings.Contains(stdoutStderr, "Versioning cannot be disabled when backups are enabled") {
+				assert.Fail(t, "The precondition checking versioning and backup configuration did not fail, but there is another error.")
+			}
+		} else {
+			// There must be an error in the precondition
+			assert.Fail(t, "There are no errors, but the precondition checking versioning and backup configuration must fail.")
+		}
+	})
+}
+```
 
 ## Development
 

--- a/stages.go
+++ b/stages.go
@@ -10,14 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// StageSetupAndInit is a helper function that sets up the environment to run validation
+// StageSetup is a helper function that sets up the environment to run validation
 // It performs the following steps:
 // 0. Copies provider configuration for the AWS provider
 // 1. Saving the terraformOptions for later stages
 // 2. Runs `terraform init` and `terraform plan`
 // 3. Verifies that the plan is not running in the remote backend.
 // 4. Executes a user specified function to validate any errors that might have occurred.
-func StageSetupInitPlan(t *testing.T, terraformDir string, terraformOptions *terraform.Options, errorFunc ...func(err error, stdoutStderr string)) {
+func StageSetup(t *testing.T, terraformDir string, terraformOptions *terraform.Options, errorFunc ...func(err error, stdoutStderr string)) {
 	// We only allow 1 errorFunc
 	if len(errorFunc) > 1 {
 		assert.FailNow(t, "You must specify exactly zero or one errorFunc's")


### PR DESCRIPTION
Renames the `StageSetupInitPlan` to `StageSetup` to have a consistent mapping of function name to stage name.
