### PR TITLE
feat: make testing easier with less overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,89 @@ All functions that init or apply the module allow you to specify an `errorFunc` 
 
 The error and the output of the terraform command are passed to that function so that you can define if the test should succeed or fail.
 
-If you need to configure a terraform provider for your tests, save that configuration in `test/provider.tf`. The helper functions will automatically copy that configuration to the module directory before the test starts and delete it afterwards.
+## Repository layout
+
+To ensure correct function of this module, you need to:
+
+- Put your tests in the directory `test`.
+- Put variable files for your tests in `test/variables` and name them as the test is named
+- Put provider configuration into the `test/provider.tf` file
 
 ## Functions
 
+### Run functions
+
+Those functions are the easy start into testing, with more complex scenarios covered below. They are called “run functions” because their name starts with `Run`.
+
+All run functions destroy the deployed infrastructure afterwards.
+Run functions abstract [stages](#stages) for you.
+
+To only run some stages, set a `SKIP_$stage` environment variable to skip a certain stage, e.g. `SKIP_destroy`. This makes developing and debugging tests much easier.
+
+For examples, see [the examples section](#examples).
+
+Available run functions are:
+
+- `RunNoValidate`: Run with default options and no extra validation
+- `RunValidate`: Same as `RunNoValidate`, but with a validation function
+- `RunOptionsNoValidate`: Run with configured terraform options, no extra validation
+- `RunOptionsValidate`: Same as `RunOptionsNoValidate`, but with a validation function
+
+In a validation function, you can inspect the deployed infrastructure and have the test fail with `assert.Fail` if it does not match what you are expecting.
+
+### Terraform Options
+
+You can use the `DefaultOptions` function for default terraformOptions to be set automatically. Those are:
+
+- `TerraformDir`, set to the absolute path of the module as the tests are in a subdirectory named `tests`
+- `VarFiles` is appended the with the `.tfvars` file in `test/variables` that has the same as the running test
+
 ### Stages
 
-When stages are used, you can set a `SKIP_$stage` environment variable to skip a certain stage, e.g. `SKIP_destroy`. This makes developing and debugging tests much easier.
+:information_source: You need stages if you expect e.g. the `terraform plan` to fail for a test and want to validate the errors that occur, see the examples below.
 
-* `StageSetup`: Saves the `terraformOptions`, runs `terraform init` and `terraform plan`. You can specify an `errorFunc` here.
-* `StageApply`: Runs `terraform apply`. You can specify an `errorFunc` here.
-* `StageValidate`: If you want to check the state of the deployed infrastructure, you can do so in the validate stage. Pass a `validateFunc` into `StageValidate`.
-* `StageDestroy`: Runs `terraform destroy` and calls the `Cleanup` function.
+Available stages are:
+
+- `setup`: Saves the `terraformOptions`, runs `terraform init` and `terraform plan`. You can specify an `errorFunc` here.
+- `apply`: Runs `terraform apply`. You can specify an `errorFunc` here.
+- `validate`: If you want to check the state of the deployed infrastructure, you can do so in the validate stage. Pass a `validateFunc` into `StageValidate`.
+- `destroy`: Runs `terraform destroy` and calls the `Cleanup` function.
 
 ### Others
 
-* `Cleanup`: Removes the test data directory `.test-data` and test provider configuration `test-provider.tf`.
+- `Cleanup`: Removes the test data directory `.test-data` and test provider configuration `test-provider.tf`.
 
-## Example
+## Examples
 
 ### Standard test
+
+```go
+func TestDefaults(t *testing.T) {
+	helpers.RunNoValidate(t)
+}
+```
+
+with this, the test will run the module with the variables in `test/variables/TestDefaults.tfvars` and expect all operations to be successful.
+
+### Specifying dynamic variables
+
+When you need to define not only constant variables, but also dynamic ones, you can use `RunOptionsNoValidate` as follows:
+
+```go
+func TestWithVars(t *testing.T) {
+	helpers.RunOptionsNoValidate(t, &terraform.Options{
+		Vars: map[string]interface{}{
+			"name": uuid.New(),
+		},
+	})
+}
+```
+
+This is needed for e.g. tests with S3 buckets to ensure every bucket is named uniquely.
+
+### Expected to fail on apply
+
+If a test is expected to fail on apply, defer the `destroy` stage and pass an error function to the `apply` stage:
 
 ```go
 func TestS3BucketDefault(t *testing.T) {
@@ -40,11 +103,18 @@ func TestS3BucketDefault(t *testing.T) {
 	})
 
 	helpers.StageSetup(t, TerraformDir, terraformOptions)
-	helpers.StageApply(t, TerraformDir)
+	helpers.StageApply(t, TerraformDir, func(err error, stdoutStderr string) {
+		// This error is expected
+		if err != nil {
+			if !strings.Contains(stdoutStderr, "Error: Some expected error") {
+				assert.Fail(t, "We expected an error, but it did not occur. Instead, another error was returned.")
+			}
+		}
+	})
 }
 ```
 
-### Expected to fail
+### Expected to fail on plan
 
 For a test that is expected to fail on plan, use the `Cleanup` function.
 

--- a/options.go
+++ b/options.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/files"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func DefaultOptions(t *testing.T, terraformOptions *terraform.Options) *terraform.Options {
+	// Check if a variable file with the name of the current test exists and use it
+	currentTestVarFile := filepath.Join("variables", fmt.Sprintf("%s.tfvars", t.Name()))
+	if files.FileExists(currentTestVarFile) {
+		terraformOptions.VarFiles = append(terraformOptions.VarFiles, filepath.Join("test", currentTestVarFile))
+	}
+
+	// By default, our terraform module is in the git repository root and our tests in the 'test' directory
+	// Therefore, the we set the TerraformDir to ".." if none is specified explicitly
+	if terraformOptions.TerraformDir == "" {
+		path, err := os.Getwd()
+		if err != nil {
+			assert.FailNow(t, "Could not get current working directory, aborting test")
+		}
+		terraformOptions.TerraformDir = filepath.Join(path, "../")
+	}
+
+	return terraform.WithDefaultRetryableErrors(t, terraformOptions)
+}

--- a/run.go
+++ b/run.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/terraform"
+)
+
+func RunValidate(t *testing.T, terraformOptions terraform.Options, validateFunc func()) {
+	RunOptionsValidate(t, &terraform.Options{}, validateFunc)
+}
+
+func RunNoValidate(t *testing.T) {
+	RunOptionsValidate(t, &terraform.Options{}, func() {})
+}
+
+// RunOptionsNoValidate runs applies and destroys the module with the configured
+// variables.
+// Use this function when for tests where you expect terraform to run successfully
+// without any additional validation.
+func RunOptionsNoValidate(t *testing.T, terraformOptions *terraform.Options) {
+	RunOptionsValidate(t, terraformOptions, func() {})
+}
+
+func RunOptionsValidate(t *testing.T, terraformOptions *terraform.Options, validateFunc func()) {
+	tOptions := *DefaultOptions(t, terraformOptions)
+
+	defer StageDestroy(t, tOptions.TerraformDir)
+	StageSetup(t, tOptions.TerraformDir, &tOptions)
+	StageApply(t, tOptions.TerraformDir)
+	StageValidate(t, validateFunc)
+}


### PR DESCRIPTION
This PR adds **run functions**, default options and more documentation.

With run functions, usage of the helpers requires even less overhead for common scenarios.

Default options make this possible by setting terraform config according to the default repository layout if not explicitly overridden.
