### PR TITLE
CORE-3855: Enable parallel testing

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08 # tag=v4
     - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # tag=v3.2.1
       with:
-        go-version: 1.18.4
+        go-version: 1.21.3
 
     - name: Setup for pre-commit
       run: make setup

--- a/options.go
+++ b/options.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gruntwork-io/terratest/modules/files"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -27,6 +28,10 @@ func DefaultOptions(t *testing.T, terraformOptions *terraform.Options) *terrafor
 		}
 		terraformOptions.TerraformDir = filepath.Join(path, "../")
 	}
+
+	// This enables parallel testing by ensuring that every TerraformDir lives in its own temporary path
+	tempTestFolder := test_structure.CopyTerraformFolderToTemp(t, terraformOptions.TerraformDir, ".")
+	terraformOptions.TerraformDir = tempTestFolder
 
 	return terraform.WithDefaultRetryableErrors(t, terraformOptions)
 }

--- a/run.go
+++ b/run.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func RunValidate(t *testing.T, terraformOptions terraform.Options, validateFunc func()) {
+func RunValidate(t *testing.T, _ terraform.Options, validateFunc func()) {
 	RunOptionsValidate(t, &terraform.Options{}, validateFunc)
 }
 


### PR DESCRIPTION
CORE-3855. This enables using `t.Parallel()` in tests by ensuring every test
is running in its own directory.

See details in https://pkg.go.dev/github.com/gruntwork-io/terratest@v0.40.20/modules/test-structure#CopyTerraformFolderToTemp

See https://github.com/anaconda/terraform-aws-s3-bucket/pull/137 for this in use.