### PR TITLE
CORE-9155: downgrade go to 1.24.6

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
     - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
       with:
-        go-version: 1.25.1
+        go-version: 1.24.6
 
     - name: Setup for pre-commit
       run: make setup

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/anaconda/terratest-helpers/v2
 
 go 1.23.0
 
-toolchain go1.25.1
+toolchain go1.24.6
 
 require github.com/gruntwork-io/terratest v0.50.0
 


### PR DESCRIPTION
- CORE-9155: downgrade go to 1.24.6
- Hopefully this helps to unblock all the stuck renovate PRs in our terraform modules